### PR TITLE
Remove double space in class name

### DIFF
--- a/app/routes/notes/new.tsx
+++ b/app/routes/notes/new.tsx
@@ -106,7 +106,7 @@ export default function NewNotePage() {
       <div className="text-right">
         <button
           type="submit"
-          className="rounded bg-blue-500  py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400"
+          className="rounded bg-blue-500 py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400"
         >
           Save
         </button>


### PR DESCRIPTION
Super minor - noticed a double space in the class name while playing around. 