### PR TITLE
fix: Make seeding happen only once for Cypress in Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,9 +94,6 @@ jobs:
       - name: 🛠 Setup Database
         run: npx prisma migrate reset --force
 
-      - name: 🌱 Seed the Database
-        run: npx prisma db seed
-
       - name: ⚙️ Build
         run: npm run build
 


### PR DESCRIPTION
Currently Cypress task for the deploy Github Action runs them in a row:

* `npx prisma migrate reset --force`
* `npx prisma db seed`

Because [`prisma migrate reset` also runs seed command](https://www.prisma.io/docs/concepts/components/prisma-migrate#reset-the-development-database), it could fail if the seed script inserts with unique keys specified for example:

<img width="984" alt="Screen Shot 2022-03-26 at 17 39 05" src="https://user-images.githubusercontent.com/736244/160233570-6999ba43-b647-4fae-b8ec-d5cbbb0fdb13.png">

We should remove explicit `npx prisma db seed` there so seed runs only once.