### PR TITLE
feat(vitest): provide a paved path for discovery of tests for *.server.ts files

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,10 +4,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { configDefaults } from "vitest/config";
+
+const defaultInclude = configDefaults.include ?? [];
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
+    include: [
+      ...defaultInclude,
+      // Provide a test "auto-discovery" convention for tests of files
+      // that follow the Remix `*.server.ts` filename convention
+      "**/__tests__/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+    ],
     globals: true,
     environment: "happy-dom",
     setupFiles: ["./test/setup-test-env.ts"],


### PR DESCRIPTION
The default `test.include` array for `vitest` is:

```ts
['**\/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']
```
> i.e. relevant files that end in `.test.ts` (or one of these other suffixes)

this is great except that the Remix convention for filenames that should _never_ appear in the client bundle is to add `.server.ts` to the filename. In other words when using the default `test.include` for `vitest`, either:

(a) `vitest` will miss any tests of "server only" files, or
(b) you can't use the "server only" filename convention

This PR augments the default `test.include` configuration from `vitest` to add a conventional place to put tests of "server only" files. With this in place, `vitest` will find `app/utils/puppies.test.ts` and it will also find `app/utils/__tests__/puppies.server.ts`.