### PR TITLE
fix: fixed typo in id for aria error messages

### DIFF
--- a/app/routes/notes/new.tsx
+++ b/app/routes/notes/new.tsx
@@ -75,7 +75,7 @@ export default function NewNotePage() {
           />
         </label>
         {actionData?.errors?.title && (
-          <div className="pt-1 text-red-700" id="title=error">
+          <div className="pt-1 text-red-700" id="title-error">
             {actionData.errors.title}
           </div>
         )}
@@ -96,7 +96,7 @@ export default function NewNotePage() {
           />
         </label>
         {actionData?.errors?.body && (
-          <div className="pt-1 text-red-700" id="body=error">
+          <div className="pt-1 text-red-700" id="body-error">
             {actionData.errors.body}
           </div>
         )}


### PR DESCRIPTION
Fixed non-matching id's aria-errormessage and id.