### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Prior to your first deployment, you'll need to do a few things:
   fly volumes create data --size 1 --app indie-stack-template-staging
   ```
 
-Now that every is set up you can commit and push your changes to your repo. Every commit to your `main` branch will trigger a deployment to your production environment, and every commit to your `dev` branch will trigger a deployment to your staging environment.
+Now that everything is set up you can commit and push your changes to your repo. Every commit to your `main` branch will trigger a deployment to your production environment, and every commit to your `dev` branch will trigger a deployment to your staging environment.
 
 If you run into any issues deploying to Fly, make sure you've followed all of the steps above and if you have, then post as many details about your deployment (including your app name) to [the Fly support community](https://community.fly.io). They're normally pretty responsive over there and hopefully can help resolve any of your deployment issues and questions.
 


### PR DESCRIPTION
This PR fixes a small typo in the README's deployment section.