### PR TITLE
fix: omit path and query string from healthcheck route

### DIFF
--- a/app/routes/healthcheck.tsx
+++ b/app/routes/healthcheck.tsx
@@ -7,11 +7,12 @@ export const loader: LoaderFunction = async ({ request }) => {
     request.headers.get("X-Forwarded-Host") ?? request.headers.get("host");
 
   try {
+    const url = new URL("/", `http://${host}`);
     // if we can connect to the database and make a simple query
     // and make a HEAD request to ourselves, then we're good.
     await Promise.all([
       prisma.user.count(),
-      fetch(`http://${host}`, { method: "HEAD" }).then((r) => {
+      fetch(url.toString(), { method: "HEAD" }).then((r) => {
         if (!r.ok) return Promise.reject(r);
       }),
     ]);


### PR DESCRIPTION
Reduces the chances for internal services to be affected by sending a malicious `Host` header to the health check route