### PR TITLE
fix: entry.client not using the new hydrateRoot

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,4 +1,4 @@
-import { hydrate } from "react-dom";
+import { hydrateRoot } from "react-dom/client";
 import { RemixBrowser } from "remix";
 
-hydrate(<RemixBrowser />, document);
+hydrateRoot(document, <RemixBrowser />);


### PR DESCRIPTION
i just saw that the indie-stack has react 18.0.0 but the entry.client was using old hydrate. Not sure if this was on purpose but on discord I was told to send a PR nonetheless.

I looked at server.entry and thought of adding `renderToReadableStream` but I think this might have more implications than I understand about remix's choices.