### PR TITLE
Add sqlite3 CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:16-bullseye-slim as base
 ENV NODE_ENV production
 
 # Install openssl for Prisma
-RUN apt-get update && apt-get install -y openssl
+RUN apt-get update && apt-get install -y openssl sqlite3
 
 # Install all node_modules, including dev dependencies
 FROM base as deps
@@ -40,6 +40,11 @@ RUN npm run build
 
 # Finally, build the production image with minimal footprint
 FROM base
+
+ENV DATABASE_URL=file:/data/sqlite.db
+
+# add shortcut for connecting to database CLI
+RUN echo "#!/bin/sh\nset -x\nsqlite3 \$DATABASE_URL" > /usr/local/bin/database-cli && chmod +x /usr/local/bin/database-cli
 
 WORKDIR /myapp
 


### PR DESCRIPTION
This adds the `sqlite3` CLI to the build, and generates a shortcut for connecting to the database. It will work in any Docker environment.

To connect to sqlite in a running Docker container, run `docker exec -ti <container> database-cli`.

On Fly.io, you can run `fly ssh console -C database-cli`.

