### PR TITLE
Build from public image with deps (faster first build)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,16 @@
+# base node image
+FROM node:16-bullseye-slim as base
+
+# set for base and all layer that inherit from it
+ENV NODE_ENV production
+
+# Install openssl for Prisma
+RUN apt-get update && apt-get install -y openssl
+
+# Install all node_modules, including dev dependencies
+FROM base as deps
+
+WORKDIR /myapp
+
+ADD package.json package-lock.json ./
+RUN npm install --production=false

--- a/Dockerfile.potential
+++ b/Dockerfile.potential
@@ -1,0 +1,42 @@
+# Setup production node_modules
+FROM mrkurt/remix-indie-stack:20230401 as production-deps
+
+WORKDIR /myapp
+
+ADD package.json package-lock.json ./
+RUN npm prune --production
+
+# Build the app
+FROM mrkurt/remix-indie-stack:20230401 as build
+
+WORKDIR /myapp
+
+ADD package.json package-lock.json ./
+RUN npm install --production=false
+
+ADD prisma .
+RUN npx prisma generate
+
+ADD . .
+RUN npm run postinstall
+RUN npm run build
+
+# Finally, build the production image with minimal footprint
+FROM node:16-bullseye-slim
+
+# set for base and all layer that inherit from it
+ENV NODE_ENV production
+
+# Install openssl for Prisma
+RUN apt-get update && apt-get install -y openssl
+
+WORKDIR /myapp
+
+COPY --from=production-deps /myapp/node_modules /myapp/node_modules
+COPY --from=build /myapp/node_modules/.prisma /myapp/node_modules/.prisma
+
+COPY --from=build /myapp/build /myapp/build
+COPY --from=build /myapp/public /myapp/public
+ADD . .
+
+CMD ["npm", "start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@remix-run/serve": "*",
         "@remix-run/server-runtime": "*",
         "bcryptjs": "^2.4.3",
+        "lru-cache": "^6.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "remix": "*",
@@ -8104,7 +8105,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13599,8 +13599,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -19672,7 +19671,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -23591,8 +23589,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@remix-run/serve": "*",
     "@remix-run/server-runtime": "*",
     "bcryptjs": "^2.4.3",
+    "lru-cache": "^6.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "*",


### PR DESCRIPTION
This creates a base Dockerfile that's published to Docker Hub: https://hub.docker.com/repository/docker/mrkurt/remix-indie-stack

Using a public base image speeds up first time builds and repeat builds that add or remove dependencies. The downside is extra complexity – building and pushing the base image can be automated with a workflow, but it's one more moving part.

This improves first build and rebuild performance after `npm add`.

```
### Performance notes:
# - First time build with base image: ~45s
# - First time build without base image: ~100s
#
# - Rebuild after npm install with base image: ~20s
# - Rebuild after npm install without base image: ~96s
```

The base image is ~1.2GB, so most of that first time build is downloading and extracting the layers.

If you think it makes sense to do this, I can finish up the PR and create the workflow for publishing a base image. It's possible the same base image can be used for both the indie and blues stacks.