### PR TITLE
Multi region deploys with Litestream

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Prior to your first deployment, you'll need to do a few things:
   fly volumes create data --size 1 --app indie-stack-template-staging
   ```
 
+- Update the `FLY_PRIMARY_REGION` environment variable in `fly.toml`. Set it to the same region as your volume (`fly volumes list`)
+
 Now that everything is set up you can commit and push your changes to your repo. Every commit to your `main` branch will trigger a deployment to your production environment, and every commit to your `dev` branch will trigger a deployment to your staging environment.
 
 ### Connecting to your database
@@ -117,6 +119,15 @@ The sqlite database lives at `/data/sqlite.db` in your deployed application. You
 ### Getting Help with Deployment
 
 If you run into any issues deploying to Fly, make sure you've followed all of the steps above and if you have, then post as many details about your deployment (including your app name) to [the Fly support community](https://community.fly.io). They're normally pretty responsive over there and hopefully can help resolve any of your deployment issues and questions.
+
+### Adding Regions
+
+The Indie stack includes Litestream for regional read replication. You can add regions by creating new volumes, then scaling the application count. To expand into Sydney, Australia, run these commands:
+
+```
+fly volumes create data --size 1 --region syd --app indie-stack-template
+fly scale count 2
+```
 
 ## GitHub Actions
 

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,9 @@ processes = []
   cmd = "start.sh"
   entrypoint = "sh"
 
+[env]
+FLY_PRIMARY_REGION="ord" #for litestream
+
 [mounts]
   source = "data"
   destination = "/data"


### PR DESCRIPTION
This adds Litestream to the build and configures read replication. There are some remaining todos to finish this up:

- [ ] Copy `fly-replay` logic over from the blues stack
- [ ] Restrict to one instance in primary region. This will not work properly with 2+ instances in the primary region
- [ ] Add config for streaming to s3. This makes streaming backups almost free.

These changes don't change much in other environments. It does start a Litestream server listening on port 9090, which is pretty useful if you want to get a copy of the sqlite db elsewhere. We could disable Litestream entirely when there's no `FLY_PRIMARY_REGION` set, too.