### PR TITLE
Add `--region` flag to `fly volumes create` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Prior to your first deployment, you'll need to do a few things:
 
   If you don't have openssl installed, you can also use [1password](https://1password.com/generate-password) to generate a random secret, just replace `$(openssl rand -hex 32)` with the generated secret.
 
-- Create a persistent volume for the sqlite database for both your staging and production environments. Run the following:
+- Create a persistent volume for the sqlite database for both your staging and production environments. Run the following, replacing `<region>` with a [Fly.io region ID](https://fly.io/docs/reference/regions/):
 
   ```sh
-  fly volumes create data --size 1 --app indie-stack-template
-  fly volumes create data --size 1 --app indie-stack-template-staging
+  fly volumes create data --size 1 --app indie-stack-template --region <region>
+  fly volumes create data --size 1 --app indie-stack-template-staging --region <region>
   ```
 
 Now that everything is set up you can commit and push your changes to your repo. Every commit to your `main` branch will trigger a deployment to your production environment, and every commit to your `dev` branch will trigger a deployment to your staging environment.


### PR DESCRIPTION
Otherwise, you'll get an `Error --region <region> flag required`.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
