### PR TITLE
Add explicit github workflow permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,10 @@ on:
     branches:
       - main
       - dev
-  pull_request: {}
+  pull_request: {} 
+permissions:
+  actions: write
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
A new repository I started from this template had default permissions for `GITHUB_TOKEN` set to "contents:read" and "metadata:read". I think this has changed recently because I use to be able to get actions running before April. I think it used to be read/write by default and now it's read:

<img width="771" alt="permissions" src="https://user-images.githubusercontent.com/23662058/168450556-21796195-ed3d-4267-b8f3-08d646db607f.png">

My workflow execution failed because styfle/cancel-workflow-action needs "actions:write" permissions (my guess is so that it can [cancel a run](https://docs.github.com/en/rest/actions/workflow-runs#cancel-a-workflow-run) or something like that).

Adding "contents:read" and "actions:write" explicitly in the workflow file made this work.