### PR TITLE
chore(Dockerfile): use wildcard for package.json and package-lock.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM base as deps
 
 WORKDIR /myapp
 
-ADD package.json package-lock.json ./
+ADD package.json ./
 RUN npm install --production=false
 
 # Setup production node_modules
@@ -21,7 +21,8 @@ FROM base as production-deps
 WORKDIR /myapp
 
 COPY --from=deps /myapp/node_modules /myapp/node_modules
-ADD package.json package-lock.json ./
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+ADD package*.json ./
 RUN npm prune --production
 
 # Build the app


### PR DESCRIPTION
the stack doesn't come with a package-lock.json since #79 causing docker builds to fail, but the file will exist after `create-remix`

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
