### PR TITLE
enh(setup): remove the remix.init folder as last step

### DIFF
--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -72,6 +72,10 @@ async function main({ rootDirectory }) {
       recursive: true,
     }),
     fs.rm(path.join(rootDirectory, ".github/PULL_REQUEST_TEMPLATE.md")),
+    fs.rm(path.join(rootDirectory, "remix.init"), {
+      recursive: true,
+      force: true,
+    }),
   ]);
 
   execSync(`npm run setup`, { stdio: "inherit", cwd: rootDirectory });


### PR DESCRIPTION
Just a proposal here: why not remove the `remix.init` folder when we're done with setup?

This will never be used after the installation, and we installed packages in it, bloating the app for nothing.
