### PR TITLE
docs: Added note about app name in fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Prior to your first deployment, you'll need to do a few things:
   fly create indie-stack-template
   fly create indie-stack-template-staging
   ```
+  > **Note:** Make sure this name matches the `app` set in your `fly.toml` file. Otherwise, you will not be able to deploy.
 
   - Initialize Git.
 


### PR DESCRIPTION
Update readme to highlight the connection between the app name set in fly.toml and the name created with fly cli.

This relates to [this issue](https://github.com/remix-run/indie-stack/issues/117) which was resolved by making sure the names align. 

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
