### PR TITLE
Update fly app creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Prior to your first deployment, you'll need to do a few things:
 - Create two apps on Fly, one for staging and one for production:
 
   ```sh
-  fly create indie-stack-template
-  fly create indie-stack-template-staging
+  fly apps create indie-stack-template
+  fly apps create indie-stack-template-staging
   ```
   > **Note:** Make sure this name matches the `app` set in your `fly.toml` file. Otherwise, you will not be able to deploy.
 


### PR DESCRIPTION
With the new Fly CLI you will get this error if you try to do `fly create xxx`:

```
Command "create" is deprecated, replaced by 'apps create'
```

The new way of creating an app is: `fly apps create xxx`.