### PR TITLE
Fix Remix.Init for TypeScript Projects

### DIFF
--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -46,9 +46,9 @@ const readFileIfNotTypeScript = (
   filePath,
   parseFunction = (result) => result
 ) =>
-  (isTypeScript ? Promise.resolve() : fs.readFile(filePath, "utf-8")).then(
-    parseFunction
-  );
+  isTypeScript
+    ? Promise.resolve()
+    : fs.readFile(filePath, "utf-8").then(parseFunction);
 
 const removeUnusedDependencies = (dependencies, unusedDependencies) =>
   Object.fromEntries(

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -73,7 +73,7 @@ const updatePackageJson = ({ APP_NAME, isTypeScript, packageJson }) => {
           "vite-tsconfig-paths",
         ]),
     prisma: isTypeScript
-      ? prisma
+      ? { ...prisma, seed: prismaSeed }
       : {
           ...prisma,
           seed: prismaSeed


### PR DESCRIPTION
Fixes #136 

- Fixed brackets in order to only call parse function if project is JavaScript
- Fixed prisma:seed property in package.json if project is TypeScript

Tested:
```sh
npx create-remix@latest --template milamer/indie-stack
? Where would you like to create your app? ./indie-stack-test
? TypeScript or JavaScript? TypeScript
? Do you want me to run `npm install`? Yes

...

Setup is complete. You're now ready to rock and roll 🤘

```