### PR TITLE
fix(ui): use object-contains for logos

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -45,7 +45,7 @@ export default function Index() {
                     </Link>
                     <Link
                       to="/login"
-                      className="flex items-center justify-center rounded-md bg-yellow-500 px-4 py-3 font-medium text-white hover:bg-yellow-600  "
+                      className="flex items-center justify-center rounded-md bg-yellow-500 px-4 py-3 font-medium text-white hover:bg-yellow-600"
                     >
                       Log In
                     </Link>
@@ -127,7 +127,7 @@ export default function Index() {
                 href={img.href}
                 className="flex h-16 w-32 justify-center p-1 grayscale transition hover:grayscale-0 focus:grayscale-0"
               >
-                <img alt={img.alt} src={img.src} />
+                <img alt={img.alt} src={img.src} className="object-contain" />
               </a>
             ))}
           </div>


### PR DESCRIPTION
Set the `object-fit` CSS property to `contain`, to **make sure logos with different aspect ratios will not be stretched** and shown properly. This stretching happens when a new logo is added to the technologies array with a different aspect ratio like 4:1. Now it's fixed.

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
