### PR TITLE
chore: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -235,6 +235,7 @@ const main = async ({ isTypeScript, packageManager, rootDirectory }) => {
     fs.rm(path.join(rootDirectory, ".github", "ISSUE_TEMPLATE"), {
       recursive: true,
     }),
+    fs.rm(path.join(rootDirectory, ".github", "dependabot.yml")),
     fs.rm(path.join(rootDirectory, ".github", "PULL_REQUEST_TEMPLATE.md")),
   ];
 


### PR DESCRIPTION
It's hard to know if GitHub Actions have a new version

I could have enabled it for normal dependencies as well, but I know @kentcdodds isn't a big fan of it + we don't have a lockfile, so it would only create PRs for major releases