### PR TITLE
fix(deploy): use `FLY_API_TOKEN` as `username` instead of `password`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,8 +152,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: registry.fly.io
-          username: x
-          password: ${{ secrets.FLY_API_TOKEN }}
+          username: ${{ secrets.FLY_API_TOKEN }}
+          password: x
 
       - name: 🐳 Docker build
         uses: docker/build-push-action@v3


### PR DESCRIPTION
Hi! As I was deploying my Indie stack app to Fly, I ran into trouble authenticating with the Fly.io Docker registry. Through some googling, I found that the Personal Access Token needs to be in the username and "x" needs to be used for the password instead of the other way around. Once I made this switch, I was able to deploy. Thanks!