### PR TITLE
chore: update gitpod url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Not a fan of bits of the stack? Fork it, change it, and use `npx create-remix --
 
 Click this button to create a [Gitpod](https://gitpod.io) workspace with the project set up and Fly pre-installed
 
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/remix-run/indie-stack/tree/main)
 
 ## Development
 


### PR DESCRIPTION
x-ref https://github.com/remix-run/blues-stack/pull/135

seems like `http://gitpod.io/from-referrer/` no longer works

<!--

👋 Hey, thanks for your interest in contributing to Remix!

Our bandwidth on maintaining these stacks is limited. As a team, we're currently
focusing our efforts on Remix itself. The good news is you can fork and adjust
this stack however you'd like and start using it today as a custom stack. Learn
more from [the Remix Stacks docs](https://remix.run/stacks).

You're still welcome to make a PR. We can't promise a timely response, but
hopefully when we have the bandwidth to work on these stacks again we can take
a look. Thanks!

-->
