### PR TITLE
fix: fix `typecheck` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 \"npx cypress open\"",
     "pretest:e2e:run": "npm run build",
     "test:e2e:run": "cross-env PORT=8811 start-server-and-test start:mocks http://localhost:8811 \"npx cypress run\"",
-    "typecheck": "tsc && tsc cypress",
+    "typecheck": "tsc && tsc -p cypress",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run"
   },
   "prettier": {},


### PR DESCRIPTION
Apparently we need to add the `-p` flag when running `tsc` on the `cypress` folder
https://github.com/remix-run/indie-stack/actions/runs/3951228293/jobs/6764810424