### PR TITLE
fix: Update docker build step to use older builder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,8 @@ jobs:
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
 
       # Setup cache
       - name: ⚡️ Cache Docker layers


### PR DESCRIPTION
A recent change to the build-runner breaks deployment.

https://community.fly.io/t/deploying-to-fly-via-github-action-failing/10171/19
