### PR TITLE
docs(Add-common-issue-to-the-README-(out-of-memory-Fly-issue)): Also …

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Prior to your first deployment, you'll need to do a few things:
   fly apps create indie-stack-template-staging
   ```
 
-  > **Note:** Make sure this name matches the `app` set in your `fly.toml` file. Otherwise, you will not be able to deploy.
+  > **Note:** Make sure to replace `indie-stack-template` with the name of the `app` set in your `fly.toml` file. Otherwise, you will not be able to deploy. You will find the name at the beginning of your `fly.toml` file, such as `app=[NAME_OF_YOUR_APP]`
 
   - Initialize Git.
 
@@ -121,6 +121,15 @@ Prior to your first deployment, you'll need to do a few things:
   fly volumes create data --size 1 --app indie-stack-template
   fly volumes create data --size 1 --app indie-stack-template-staging
   ```
+
+- Increate the size of the memory for both your staging and production environments. This allows you to go around [a `Out of memory` issue when installing `prisma` on your `fly` virtual machines](https://github.com/remix-run/indie-stack/issues/156).
+Run the following:
+
+   ```sh
+   flyctl scale memory 512 --app indie-stack-template 
+   flyctl scale memory 512 --app indie-stack-template-staging
+   ```
+
 
 Now that everything is set up you can commit and push your changes to your repo. Every commit to your `main` branch will trigger a deployment to your production environment, and every commit to your `dev` branch will trigger a deployment to your staging environment.
 


### PR DESCRIPTION
Hi,

This PR addresses a couple of points from the README that might prevent newcomers from fully enjoying Remix.

I experience the `out of memory` bug on a vanilla install of the stack.

This PR address two issues:

 - Add to the README a couple of shell commands to run to increase the memory of the VMS. Without this, you run into an `out of memory` issue during the deploy phase. This has been experienced previously here (https://github.com/remix-run/indie-stack/issues/156).
 
 - Reword the paragraph about replacing the name when running the shell commands. It is not critical but I know that Remix targets also beginner web developers. I found the paragraph about renaming the app name slightly obscure, I made it more explicit.

Keep up the good work! Thank you!

PS: feel free to edit my wording, English isn't my first language.