### PR TITLE
chore: rollback Docker Buildx workaround

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,8 +138,6 @@ jobs:
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.9.1
 
       # Setup cache
       - name: ⚡️ Cache Docker layers


### PR DESCRIPTION
Fly.io has fixed the root cause of the build/deploy issue. 

https://community.fly.io/t/images-built-with-the-latest-docker-buildx-and-or-github-actions-work-again/10816
