### PR TITLE
feat: add `css-bundle` setup

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,12 +8,14 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
+import { cssBundleHref } from "@remix-run/css-bundle";
 
 import { getUser } from "~/session.server";
 import tailwindStylesheetUrl from "~/styles/tailwind.css";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: tailwindStylesheetUrl },
+  ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
 ];
 
 export const loader = async ({ request }: LoaderArgs) => {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "@prisma/client": "^4.12.0",
+    "@remix-run/css-bundle": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/serve": "*",


### PR DESCRIPTION
This ensures CSS bundling doesn't need to be manually set up before using any CSS bundling features which is particularly important since they'll be enabled by default in v1.16. By default this has no impact on the links returned from this app so there's zero cost for consumers.