### PR TITLE
fix: use exact Cypress version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "binode": "^1.0.5",
     "cookie": "^0.5.0",
     "cross-env": "^7.0.3",
-    "cypress": "^12.17.4",
+    "cypress": "12.17.3",
     "eslint": "^8.47.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-cypress": "^2.14.0",


### PR DESCRIPTION
Regression in Cypress with using `Cypress.Command.add`

Closes #251