### PR TITLE
fix: load Cypress commands in newer versions

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -90,6 +90,8 @@ function visitAndCheck(url: string, waitTime: number = 1000) {
   cy.location("pathname").should("contain", url).wait(waitTime);
 }
 
-Cypress.Commands.add("login", login);
-Cypress.Commands.add("cleanupUser", cleanupUser);
-Cypress.Commands.add("visitAndCheck", visitAndCheck);
+export function registerCommands() {
+  Cypress.Commands.add("login", login);
+  Cypress.Commands.add("cleanupUser", cleanupUser);
+  Cypress.Commands.add("visitAndCheck", visitAndCheck);
+}

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,5 +1,7 @@
 import "@testing-library/cypress/add-commands";
-import "./commands";
+import { registerCommands } from "./commands";
+
+registerCommands();
 
 Cypress.on("uncaught:exception", (err) => {
   // Cypress and React Hydrating the document don't get along

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "binode": "^1.0.5",
     "cookie": "^0.5.0",
     "cross-env": "^7.0.3",
-    "cypress": "12.17.3",
+    "cypress": "^12.17.4",
     "eslint": "^8.47.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-cypress": "^2.14.0",


### PR DESCRIPTION
Newer versions of Cypress (12.17.4+) do not load commands.ts because
of sideEffects: false in package.json:

https://github.com/cypress-io/cypress/issues/27641

This is probably caused by Webpack 5 skipping the import. The fix is to
explicitly register the commands without relying on side effects. This
allows upgrading Cypress to 12.17.4+ or 13+ (13 worked fine for me).

This PR provides a more future-proof fix to #251 than PR #254.