### PR TITLE
use generic types for cy.then and cy.get aliases

### DIFF
--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -11,7 +11,7 @@ describe("smoke tests", () => {
       password: faker.internet.password(),
     };
 
-    cy.then(() => ({ email: loginForm.email })).as("user");
+    cy.then<{ email: string }>(() => ({ email: loginForm.email })).as("user");
 
     cy.visitAndCheck("/");
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -47,7 +47,7 @@ function login({
 }: {
   email?: string;
 } = {}) {
-  cy.then(() => ({ email })).as("user");
+  cy.then<{ email: string }>(() => ({ email })).as("user");
   cy.exec(
     `npx ts-node --require tsconfig-paths/register ./cypress/support/create-user.ts "${email}"`,
   ).then(({ stdout }) => {
@@ -56,15 +56,14 @@ function login({
       .trim();
     cy.setCookie("__session", cookieValue);
   });
-  return cy.get("@user");
+  return cy.get<{ email?: string }>("@user");
 }
 
 function cleanupUser({ email }: { email?: string } = {}) {
   if (email) {
     deleteUserByEmail(email);
   } else {
-    cy.get("@user").then((user) => {
-      const email = (user as { email?: string }).email;
+    cy.get<{ email?: string }>("@user").then(({ email }) => {
       if (email) {
         deleteUserByEmail(email);
       }


### PR DESCRIPTION
Hey all!

This is a small pr that, it seems to me, slightly improves the typing in Cypress when using aliases.

This is a move away from type assertion to a slightly more formal system.

This can help developers immediately see the format for working with aliases in their projects.

I was inspired by this https://github.com/cypress-io/cypress/issues/8762#issuecomment-1192080000. 

This is how I made it work in my application. 
https://github.com/antonkri97/family/pull/7/files#diff-ecc0256f03e3c2246926d3533817ed8df3416df522a4edee7b89a27a972d56a8

I moved all the aliases into a separate file. If you think it's a good idea, I could put these types in a separate place too.

Thanks :)