### PR TITLE
infer useMatchesData type using generic

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,3 +1,4 @@
+import { type SerializeFrom } from '@remix-run/node'
 import { useMatches } from "@remix-run/react";
 import { useMemo } from "react";
 
@@ -33,16 +34,17 @@ export function safeRedirect(
  * @param {string} id The route id
  * @returns {JSON|undefined} The router data or undefined if not found
  */
-export function useMatchesData(
-  id: string,
-): Record<string, unknown> | undefined {
-  const matchingRoutes = useMatches();
-  const route = useMemo(
-    () => matchingRoutes.find((route) => route.id === id),
-    [matchingRoutes, id],
-  );
-  return route?.data as Record<string, unknown>;
+export function useMatchesData<T = Record<string, unknown> | undefined>(
+	id: string,
+): SerializeFrom<T> {
+	const matchingRoutes = useMatches()
+	const route = useMemo(
+		() => matchingRoutes.find(route => route.id === id),
+		[matchingRoutes, id],
+	)
+	return route?.data as SerializeFrom<T>
 }
+
 
 function isUser(user: unknown): user is User {
   return (


### PR DESCRIPTION
This PR makes it possible to infer the returned type of `useMatchesData` with a generic type.

This makes it possible to export a hook from a layout route:

```tsx
// app/routes/book.tsx
function useServices() {
	const { services } = useMatchesData<typeof loader>('routes/book')
	return services
}
```

and automatically infer the data in a child route:

```tsx
// app/routes/book.schedule.tsx
const services = useServices() // services is typed correctly
```

This will not be a breaking change, because the default type will be the same as the cast type currently.