### PR TITLE
Add MSW setup instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@
 .env
 /.cache
 /public/build
+/public/mockServiceWorker.js
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 
 /build
 /public/build
+/public/mockServiceWorker.js
 .env
 
 /cypress/screenshots

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ The database seed script creates a new user with some data you can use to get st
 - Email: `rachel@remix.run`
 - Password: `racheliscool`
 
+- Set up [MSW](https://mswjs.io) for local mocking
+
+```sh
+npx msw init public  --save
+```
+
+This will create a file at `public/mockServiceWorker.js` that will let MSW mock requests in the browser. See [mocks/README.md](mocks/README.md) for more context.
+
 ### Relevant code:
 
 This is a pretty simple note-taking app, but it's a good example of how you can build a full stack app with Prisma and Remix. The main functionality is creating users, logging in and out, and creating and deleting notes.


### PR DESCRIPTION
See #291 for some additional details.

With the current setup guide, users will get 404s in their terminal looking for `mockServiceWorker.js`. 

This PR adds `msw init` to the setup guide, and adds the generated `public/mockServiceWorker.js` file to `.gitignore` and `.dockerignore` to minimize likelihood of it getting packaged for prod.

I went back and forth on whether this makes more sense in the `## Development` section, or as a new `### Mocking` section under `## Testing`. Happy to make that change or any rephrase y'all prefer.