### PR TITLE
fix(deps): rollback bad version bump of superfly/flyctl-actions/setup-flyctl

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,7 @@ jobs:
           field: app
 
       - name: 🎈 Setup Fly
-        uses: superfly/flyctl-actions/setup-flyctl@v2
+        uses: superfly/flyctl-actions/setup-flyctl@v1
 
       - name: 🚀 Deploy Staging
         if: ${{ github.ref == 'refs/heads/dev' }}


### PR DESCRIPTION
Fixes  #288.

There was a bad version bump of this action and the merged PR build failed because v2 does not exist.