### PR TITLE
Fix failing project creation from this template

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-testing-library": "^6.2.2",
+    "graphql": "^16.9.0",
     "happy-dom": "^14.12.3",
     "msw": "^2.3.1",
     "npm-run-all": "^4.1.5",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,4 @@
 /** @type {import("prettier").Config} */
-export default {
+module.exports = {
   plugins: ["prettier-plugin-tailwindcss"],
 };


### PR DESCRIPTION
This PR changes the `prettier.config.js` export type to CommonJS to fix the currently failing project creation from this template.

Without this change, prettier is unable to parse the `prettier.config.js` file ([more context](https://prettier.io/blog/2023/07/05/3.0.0.html#support-config-files-in-esm-13130httpsgithubcomprettierprettierpull13130-by-fiskerhttpsgithubcomfisker)) and so the project creation from this template fails.

Fixes https://github.com/remix-run/indie-stack/issues/294