### PR TITLE
chore: Update README.md to include dependency install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ Click this button to create a [Gitpod](https://gitpod.io) workspace with the pro
 
 ## Development
 
-- First run this stack's `remix.init` script and commit the changes it makes to your project.
+- Install stack dependencies:
+
+  ```sh
+  npm install
+  ```
+
+- Run this stack's `remix.init` script and commit the changes it makes to your project.
 
   ```sh
   npx remix init


### PR DESCRIPTION
The **Development** section did not include the usual `npm install` step, so one was added.
For most devs this is an obvious step in project setup, but ought to be included to fully disambiguate the process.
